### PR TITLE
A few Docker Compose tweaks

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     build:
       context: compose
       dockerfile: Dockerfile.postgis
+    pull_policy: build
     ports:
       - "5433:5432"
     environment:
@@ -31,6 +32,7 @@ services:
       context: .
       target: dev
     image: pbaabp:docker-compose
+    pull_policy: build
     environment: &base_environment
       DEBUG: "True"
       DATABASE_URL: postgresql://pbaabp:pbaabp@postgres:5432/pbaabp
@@ -45,6 +47,7 @@ services:
 
   web:
     image: pbaabp:docker-compose
+    pull_policy: never
     command: uv run python manage.py runserver 0.0.0.0:8000
     environment: *base_environment
     volumes:
@@ -69,6 +72,7 @@ services:
 
   worker:
     image: pbaabp:docker-compose
+    pull_policy: never
     command: uv run hupper -m celery -A pbaabp worker --beat -l DEBUG
     environment: *base_environment
     volumes:
@@ -81,6 +85,7 @@ services:
 
   discord:
     image: pbaabp:docker-compose
+    pull_policy: never
     command: python manage.py run_dev_discord
     environment: *base_environment
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 volumes:
   lazer:
+  pgdata:
 
 services:
   postgres:
@@ -15,6 +16,8 @@ services:
       POSTGRES_PASSWORD: pbaabp
       POSTGRES_DB: pbaabp
       POSTGRES_HOST_AUTH_METHOD: trust  # never do this in production!
+    volumes:
+      - pgdata:/var/lib/postgresql/data
     healthcheck:
       test: ["CMD", "pg_isready", "-U", "pbaabp", "-d", "pbaabp"]
       interval: 1s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,7 @@ services:
       target: dev
     image: pbaabp:docker-compose
     pull_policy: build
+    command: ["bash", "-c", "exit 0"]
     environment: &base_environment
       DEBUG: "True"
       DATABASE_URL: postgresql://pbaabp:pbaabp@postgres:5432/pbaabp

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,6 +57,8 @@ services:
     ports:
       - "8000:8000"
     depends_on:
+      base:
+        condition: service_completed_successfully
       redis:
         condition: service_healthy
       postgres:
@@ -79,6 +81,8 @@ services:
     volumes:
       - *base_volumes
     depends_on:
+      base:
+        condition: service_completed_successfully
       redis:
         condition: service_healthy
       postgres:
@@ -93,6 +97,8 @@ services:
       - *base_volumes
     stop_signal: SIGINT
     depends_on:
+      base:
+        condition: service_completed_successfully
       redis:
         condition: service_healthy
       postgres:


### PR DESCRIPTION
## Describe your changes
Fixed a few small docker-related things I noticed when starting the project:

- add a volume for database data
- set `pull_policy: build` for the `base` and `postgis` images, and set `pull_policy: never` for the services that use the `base` image
- specify a noop command for the base container so that when we run `docker compose up`, we don't see the base container's help text in the logs 
- wait for the base container to build and exit before starting the services that use it with `condition: service_completed_successfully` 



## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
