### PR TITLE
Add PBA profile heatmap capability

### DIFF
--- a/profiles/admin.py
+++ b/profiles/admin.py
@@ -2,6 +2,7 @@ import csv
 import datetime
 import json
 from collections import defaultdict
+from django.shortcuts import render
 from io import BytesIO
 
 from admin_extra_buttons.api import ExtraButtonsMixin, button

--- a/profiles/admin.py
+++ b/profiles/admin.py
@@ -1,5 +1,6 @@
 import csv
 import datetime
+import json
 from collections import defaultdict
 from io import BytesIO
 

--- a/profiles/admin.py
+++ b/profiles/admin.py
@@ -18,6 +18,7 @@ from email_log.models import Email
 from reportlab.lib.units import inch as rl_inch
 from reportlab.pdfgen import canvas
 
+from campaigns.admin import randomize_lat_long
 from facets.models import District, RegisteredCommunityOrganization
 from membership.models import Membership
 from pbaabp.admin import OrganizerPerms, ReadOnlyLeafletGeoAdminMixin, organizer_admin
@@ -314,6 +315,17 @@ class OrganizesDistrictInline(admin.TabularInline):
     verbose_name = "District"
     verbose_name_plural = "Districts Organized"
     extra = 0
+
+
+def heatmap(modeladmin, request, queryset):
+    pins = []
+    for profile in queryset:
+        if profile.location:
+            lat, lng = randomize_lat_long(
+                profile.id, profile.location.y, profile.location.x
+            )
+            pins.append([lat, lng, 1])
+    return render(request, "petition/heatmap.html", {"pins_json": json.dumps(pins)})
 
 
 class ProfileAdmin(ExtraButtonsMixin, ReadOnlyLeafletGeoAdminMixin, admin.ModelAdmin):

--- a/profiles/admin.py
+++ b/profiles/admin.py
@@ -364,7 +364,7 @@ class ProfileAdmin(ExtraButtonsMixin, ReadOnlyLeafletGeoAdminMixin, admin.ModelA
     ]
     inlines = [OrganizesDistrictInline]
     autocomplete_fields = ("user",)
-    actions = ["resync_apps_connected"]
+    actions = [heatmap, resync_apps_connected]
 
     def _enqueue_connected_role_sync(self, profile):
         discord = profile.discord

--- a/profiles/admin.py
+++ b/profiles/admin.py
@@ -364,7 +364,7 @@ class ProfileAdmin(ExtraButtonsMixin, ReadOnlyLeafletGeoAdminMixin, admin.ModelA
     ]
     inlines = [OrganizesDistrictInline]
     autocomplete_fields = ("user",)
-    actions = [heatmap, resync_apps_connected]
+    actions = [heatmap, "resync_apps_connected"]
 
     def _enqueue_connected_role_sync(self, profile):
         discord = profile.discord

--- a/profiles/admin.py
+++ b/profiles/admin.py
@@ -323,9 +323,7 @@ def heatmap(modeladmin, request, queryset):
     pins = []
     for profile in queryset:
         if profile.location:
-            lat, lng = randomize_lat_long(
-                profile.id, profile.location.y, profile.location.x
-            )
+            lat, lng = randomize_lat_long(profile.id, profile.location.y, profile.location.x)
             pins.append([lat, lng, 1])
     return render(request, "petition/heatmap.html", {"pins_json": json.dumps(pins)})
 


### PR DESCRIPTION
## Describe your changes

Adding the ability for Admins to generate a graphical heatmap of PBA Accounts (PBA Profiles) in Django backend.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update