### PR TITLE
Update lazer_app to run in Node 24 (GitHub Actions, Dockerfile)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,7 +165,7 @@ jobs:
         if: steps.filter.outputs.lazer == 'true'
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: lazer_app/projectLazer/package-lock.json
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # ---- Lazer production build ----
-FROM node:22-bookworm AS lazer-build
+FROM node:24-trixie AS lazer-build
 WORKDIR /code/
 COPY ./lazer_app/projectLazer/package.json ./lazer_app/projectLazer/package-lock.json ./
 RUN --mount=type=cache,target=/root/.npm,sharing=locked npm ci
@@ -7,7 +7,7 @@ COPY ./lazer_app/projectLazer/ ./
 RUN npm run ionic:build:before && BUILD_ENV=production npm run build
 
 # ---- Lazer dev (watch mode via docker-compose) ----
-FROM node:22-bookworm AS lazer-dev
+FROM node:24-trixie AS lazer-dev
 WORKDIR /code/lazer_app/projectLazer/
 COPY ./lazer_app/projectLazer/package.json ./lazer_app/projectLazer/package-lock.json ./
 RUN --mount=type=cache,target=/root/.npm,sharing=locked npm install

--- a/lazer_app/projectLazer/Dockerfile
+++ b/lazer_app/projectLazer/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-bookworm AS build
+FROM node:24-trixie AS build
 
 WORKDIR /code/
 COPY ./ /code/

--- a/lazer_app/projectLazer/package.json
+++ b/lazer_app/projectLazer/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.1",
   "author": "Philly Bike Action",
   "homepage": "https://bikeaction.org/laser",
+  "engines": {
+    "node": ">=24.0.0"
+  },
   "scripts": {
     "ionic:build:before": "node scripts/update-version.js",
     "ng": "ng",


### PR DESCRIPTION
All of the npm dependabot updates are failing because there's some optional peerDependencies that disappear when running `npm ci`. This is because npm's dependency resolution algorithm is different between v10, bundled with Node 22, and v11, bundled with Node 24. 

I believe updating to run on Node 24 will then allow all the dependabot PRs to start passing, which you can test by running `npm update hono` and using Node 24 locally to run `npm ci`.