### PR TITLE
Give organizers access to Mail Links

### DIFF
--- a/maillinks/admin.py
+++ b/maillinks/admin.py
@@ -3,6 +3,7 @@ from django.urls import reverse
 from django.utils.html import format_html
 
 from maillinks.models import MailLink
+from pbaabp.admin import OrganizerPerms, organizer_admin
 
 
 class MailLinkAdmin(admin.ModelAdmin):
@@ -21,4 +22,16 @@ class MailLinkAdmin(admin.ModelAdmin):
         )
 
 
+class OrganizerMailLinkAdmin(OrganizerPerms, MailLinkAdmin):
+    def has_add_permission(self, request):
+        return self.has_module_permission(request)
+
+    def has_change_permission(self, request, obj=None):
+        return self.has_module_permission(request)
+
+    def has_delete_permission(self, request, obj=None):
+        return False
+
+
 admin.site.register(MailLink, MailLinkAdmin)
+organizer_admin.register(MailLink, OrganizerMailLinkAdmin)

--- a/maillinks/tests.py
+++ b/maillinks/tests.py
@@ -1,10 +1,13 @@
+from types import SimpleNamespace
 from unittest.mock import PropertyMock, patch
 
 from django.contrib.auth import get_user_model
-from django.test import TestCase
+from django.test import RequestFactory, SimpleTestCase, TestCase
 from django.urls import reverse
 
+from maillinks.admin import OrganizerMailLinkAdmin
 from maillinks.models import MailLink
+from pbaabp.admin import organizer_admin
 from profiles.models import Profile
 
 User = get_user_model()
@@ -12,6 +15,37 @@ User = get_user_model()
 
 def _patch_is_organizer(value):
     return patch.object(Profile, "is_organizer", new_callable=PropertyMock, return_value=value)
+
+
+class OrganizerMailLinkAdminTests(SimpleTestCase):
+    def setUp(self):
+        self.model_admin = organizer_admin._registry[MailLink]
+        self.request = RequestFactory().get("/organizer/maillinks/maillink/")
+
+    def set_organizer(self, is_organizer):
+        self.request.user = SimpleNamespace(
+            is_authenticated=True,
+            profile=SimpleNamespace(is_organizer=is_organizer),
+        )
+
+    def test_mail_links_are_registered_in_organizer_admin(self):
+        self.assertIsInstance(self.model_admin, OrganizerMailLinkAdmin)
+
+    def test_organizers_can_view_create_and_change_but_not_delete(self):
+        self.set_organizer(True)
+
+        self.assertTrue(self.model_admin.has_view_permission(self.request))
+        self.assertTrue(self.model_admin.has_add_permission(self.request))
+        self.assertTrue(self.model_admin.has_change_permission(self.request))
+        self.assertFalse(self.model_admin.has_delete_permission(self.request))
+
+    def test_non_organizers_do_not_receive_mail_link_permissions(self):
+        self.set_organizer(False)
+
+        self.assertFalse(self.model_admin.has_view_permission(self.request))
+        self.assertFalse(self.model_admin.has_add_permission(self.request))
+        self.assertFalse(self.model_admin.has_change_permission(self.request))
+        self.assertFalse(self.model_admin.has_delete_permission(self.request))
 
 
 class MailLinkActiveAccessTests(TestCase):


### PR DESCRIPTION
## Describe your changes

- Register `MailLink` with the Organizer admin using the existing organizer permission mixin.
- Allow organizers to view, create, edit, activate, and deactivate Mail Links.
- Keep Mail Link deletion disabled in the Organizer admin.
- Add focused tests for registration and organizer/non-organizer permissions.

This gives organizers the requested workflow without granting the permissions through Django's default admin.

## Issue ticket number and link

Closes #314

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Any other notes

Validation:
- `make test maillinks` — 7 tests passed
- `make lint` — passed
- `git diff --check` — passed

AI assistance disclosure: This contribution was prepared with OpenAI Codex assistance. The final diff and validation results were reviewed before submission.
